### PR TITLE
Add CI for compilation on multiple platforms (Linux, macoOS, Windows)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,7 +1,7 @@
 name: C++ CI Workflow
 
 on:
-  push:
+  workflow_dispatch:
   pull_request:
   schedule:
   # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -1,7 +1,7 @@
 name: C++ CI Workflow
 
 on:
-  push:
+  workflow_dispatch:
   pull_request:
   schedule:
   # * is a special character in YAML so you have to quote this string

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -30,6 +30,15 @@ jobs:
       with:
         environment-file: ci_env.yml
 
+    # Additional dependencies useful only on Linux
+    - name: Additional Dependencies (Linux])
+      if: contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        # Additional dependencies only useful on Linux
+        # See https://github.com/robotology/robotology-superbuild/issues/477
+        micromamba install expat-cos6-x86_64 freeglut libselinux-cos6-x86_64 libxau-cos6-x86_64 libxcb-cos6-x86_64 libxdamage-cos6-x86_64 libxext-cos6-x86_64 libxfixes-cos6-x86_64 libxxf86vm-cos6-x86_64 mesa-libgl-cos6-x86_64 mesa-libgl-devel-cos6-x86_64
+
     - name: Configure VS Toolchain (Windows)
       if: contains(matrix.os, 'windows')
       uses: ilammy/msvc-dev-cmd@v1.12.1

--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -1,0 +1,70 @@
+name: C++ CI Workflow
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
+
+jobs:
+  build-with-conda-dependencies:
+    name: '[conda:${{ matrix.os }}]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-22.04, macos-latest, windows-2019]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Print used environment (no conda)
+      shell: bash -l {0}
+      run: |
+        env
+
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: ci_env.yml
+
+    - name: Configure VS Toolchain (Windows)
+      if: contains(matrix.os, 'windows')
+      uses: ilammy/msvc-dev-cmd@v1.12.1
+
+    - name: Setup compilation env variables (Windows)
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        bash_vc_install=${VCToolsInstallDir//\\//}
+        compiler_path=${bash_vc_install}bin/Hostx64/x64/cl.exe
+        echo "CC=${compiler_path}" >> $GITHUB_ENV
+        echo "CXX=${compiler_path}" >> $GITHUB_ENV
+
+    - name: Configure
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build    
+        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DBUILD_TESTING:BOOL=ON ..
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }} 
+
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest  --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} . 
+
+    # This is commented until we fix https://github.com/robotology/gz-yarp-plugins/issues/28
+    # - name: Install
+    #  run: |
+    #    cd build
+    #    cmake --build . --config ${{ matrix.build_type }} --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 gz_find_package(gz-sim7 REQUIRED)
 set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
 
+# Support shared libraries on Windows
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_subdirectory(libraries)
 add_subdirectory(plugins)

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -8,3 +8,4 @@ dependencies:
   - ninja
   - pkg-config
   - libgz-sim7
+  - yarp

--- a/ci_env.yml
+++ b/ci_env.yml
@@ -1,0 +1,10 @@
+name: gzyarppluginsdev
+channels:
+  - conda-forge
+dependencies:
+  - cmake
+  - compilers
+  - make
+  - ninja
+  - pkg-config
+  - libgz-sim7

--- a/plugins/camera/singleton-camera/Handler.hh
+++ b/plugins/camera/singleton-camera/Handler.hh
@@ -1,4 +1,5 @@
 #include <mutex>
+#include <string>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 #include <gz/common/Event.hh>

--- a/plugins/forcetorque/singleton-forcetorque/Handler.hh
+++ b/plugins/forcetorque/singleton-forcetorque/Handler.hh
@@ -1,4 +1,6 @@
+#include <array>
 #include <mutex>
+#include <string>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 #include <gz/common/Event.hh>

--- a/plugins/imu/singleton-imu/Handler.hh
+++ b/plugins/imu/singleton-imu/Handler.hh
@@ -1,4 +1,6 @@
+#include <array>
 #include <mutex>
+#include <string>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 #include <gz/common/Event.hh>

--- a/plugins/laser/singleton-laser/Handler.hh
+++ b/plugins/laser/singleton-laser/Handler.hh
@@ -1,4 +1,6 @@
 #include <mutex>
+#include <string>
+#include <vector>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/PolyDriverList.h>
 #include <gz/common/Event.hh>


### PR DESCRIPTION
This PR adds compilation of the library aganst dependencies on Linux, macOS and Windows, installing the dependencies via the [conda-forge](https://conda-forge.org/) conda channel.

As compilaton on Windows was not working,  also added the following fixes:
* https://github.com/robotology/gz-yarp-plugins/pull/29/commits/e551e6dd5a8e40bb60f2724e423b311644748063
* https://github.com/robotology/gz-yarp-plugins/pull/29/commits/19c3cc0d510c23fa14769ae6feecf2980f33a48c