### PR TITLE
apt: Enable running job on push on main branch

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,6 +1,9 @@
 name: C++ CI Workflow
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   pull_request:
   schedule:


### PR DESCRIPTION
This should ensure that codecov gets useful base information to proper compute the difference in coverage in new PRs, see https://github.com/robotology/gz-yarp-plugins/pull/32#issuecomment-1677628384 .